### PR TITLE
Add AI for Database to Data Engineering & Analytics Agents (Section 19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Automated systems that ingest chaotic data environments, generate complex SQL/Py
 | **Dataherald** | Natural Language-to-SQL engine constructed over relational databases, supporting RAG-style schema alignment and determinism. | Python | Hybrid | Web UI | [Link](https://github.com/Dataherald/dataherald) |
 | **PandasAI** | Conversational data analysis library that allows users to interact with their databases and dataframes using natural language. | Python | API-based | Jupyter | [Link](https://github.com/sinaptik-ai/pandas-ai) |
 | **LlamaIndex** | Though a data framework, its Agentic Data Engines autonomously route, synthesis, and query disparate vector and SQL nodes. | Python/TS | Hybrid | Library | [Link](https://github.com/run-llama/llama_index) |
+| **AI for Database** | Agentic AI that connects to any database (Postgres, MySQL, MongoDB) and enables natural language querying, self-refreshing dashboards, and workflow automation. | SaaS | Hybrid | Web UI | [Link](https://aifordatabase.com) |
 
 ---
 


### PR DESCRIPTION
## AI for Database

Adding [AI for Database](https://aifordatabase.com) to Section 19 (Data Engineering and Analytics Agents).

**What it does:** Connects to any database (PostgreSQL, MySQL, MongoDB, and more) and enables natural language querying — no SQL required. Also provides self-refreshing dashboards and automated workflow triggers based on database changes.

**Why it belongs here:** It is a purpose-built agentic AI product for databases — it autonomously handles query generation, schema understanding, and result interpretation. It fits directly alongside Dataherald and PandasAI in the NL-to-SQL/conversational data analysis space, with added agentic workflow capabilities.

Pricing: Freemium