### PR TITLE
feat: add NotFair - Claude Code skills for SEO, Google Ads, and Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ Optimized semantic processing for professional and regulated fields.
 | **Octochains** | Strict execution conditionals based on regulatory risks. | TS/Python | API-based | Web UI | [Link](https://github.com/ahmadvh/octochains) |
 | **LawAgent** | Sub-routines for iterative structuring of legal opinions. | Python | API-based | Web UI | [Link](https://github.com/AI-Hub-Admin/LawAgent) |
 
+### Marketing and Advertising
+| Project | Description | Stack | Engine | Deployment | Link |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **NotFair** | Claude Code skill set for SEO, GEO, Google Ads, and Meta Ads. Connects to live account data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to execute audits, keyword research, creative analysis, and bid management. | TypeScript | API-based | CLI | [Link](https://github.com/nowork-studio/NotFair) |
+
 ---
 
 ## 12. Memory and Persistence for Agents


### PR DESCRIPTION
Hi! Thank you for maintaining this excellent AI agents directory.

I'd like to suggest adding **NotFair** (https://github.com/nowork-studio/NotFair) to the **Specialized Agents → Marketing and Advertising** subsection, which I've added as a natural complement to the existing Finance, Medicine, and Legal subsections.

NotFair is an open-source set of Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars, MIT license). Rather than being a standalone agent, it plugs directly into Claude Code and connects to live advertising and analytics data through four MCPs: **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**. This lets it execute real audits, keyword research, wasted-spend detection, creative fatigue analysis, and bid management against actual accounts — fitting the "operational parity with human counterparts" standard described in this repo's intro.

Happy to reword the description, adjust the section placement, or trim any details to better match the list's style. Thanks for the consideration!