### PR TITLE
Add Hermes to Voice and Real-Time Audio Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Frameworks and pipelines optimized for low-latency voice-to-voice communication,
 | **Vapi** | End-to-end voice AI platform abstraction allowing integration of interrupting, context-aware audio agents natively via SIP/WebRTC. | TypeScript | API-based | Web/App | [Link](https://github.com/VapiAI) |
 | **OmniChat** | Real-time voice agent framework supporting full-duplex audio with interruption handling and emotion detection. | Python | API-based | Docker | [Link](https://github.com/opengvlab/omnichat) |
 | **Retell AI** | Voice agent API with turn-taking logic, keyword detection, and custom voice cloning for agent personas. | TypeScript | API-based | API | [Link](https://github.com/RetellAI) |
+| **Hermes** | Operating platform for AI voice agencies: multi-tenant voice agents with built-in CRM, campaign orchestration, white-label client portals, and usage-based billing in one system. | SaaS | API-based | Web | [Link](https://www.buildwithhermes.com) |
 
 ---
 


### PR DESCRIPTION
Adds Hermes (buildwithhermes.com) to section 21, Voice and Real-Time Audio Agents.

Why it fits this section: the table already covers the voice-agent platform tier (Vapi, Retell AI). Hermes covers the layer above the raw API: a multi-tenant operating platform for teams running voice agents for multiple clients, with CRM, campaign orchestration, white-label portals, and usage billing built in. It rounds out the section for readers comparing build-on-an-API vs run-on-a-platform options.

Formatted to match the existing table columns. Happy to adjust wording or placement if you prefer.