### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Semantic hypervectorial storage persisting across context limitations.
 | **Zep** | Asynchronous collector and heuristic router for short-term memory. | Go/Docker | Hybrid | Docker | [Link](https://github.com/getzep/zep) |
 | **Graphiti** | Entity compilation into dynamic graph and relation meshes. | Python | API-based | Library | [Link](https://github.com/getzep/graphiti) |
 | **AgentMemory** | Indexable segmented vectors focused on code dependencies. | Python | Local Inference | CLI | [Link](https://github.com/rohitg00/agentmemory) |
-| **Tree Ring Memory** | Scoped recall lifecycle storing audit trails, redaction events, forgetting, and consolidation in local SQLite/FTS stores. | Rust/SQLite | N/A | CLI/TUI | [Link](https://github.com/TerminallyLazy/Tree-Ring-Memory) |
+| **Tree Ring Memory** | Local-first memory lifecycle layer with scoped recall, forgetting, and consolidation. | Rust/SQLite | N/A | CLI | [Link](https://github.com/TerminallyLazy/Tree-Ring-Memory) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Semantic hypervectorial storage persisting across context limitations.
 | **Zep** | Asynchronous collector and heuristic router for short-term memory. | Go/Docker | Hybrid | Docker | [Link](https://github.com/getzep/zep) |
 | **Graphiti** | Entity compilation into dynamic graph and relation meshes. | Python | API-based | Library | [Link](https://github.com/getzep/graphiti) |
 | **AgentMemory** | Indexable segmented vectors focused on code dependencies. | Python | Local Inference | CLI | [Link](https://github.com/rohitg00/agentmemory) |
+| **Tree Ring Memory** | Scoped recall lifecycle storing audit trails, redaction events, forgetting, and consolidation in local SQLite/FTS stores. | Rust/SQLite | N/A | CLI/TUI | [Link](https://github.com/TerminallyLazy/Tree-Ring-Memory) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Tree Ring Memory to section 15, Memory and Persistence for Agents.

Tree Ring Memory is a local-first memory lifecycle layer for agents, using Rust CLI/TUI surfaces and local SQLite/FTS stores for scoped recall, audit trails, redaction events, forgetting, and consolidation.

## Validation

- Read `CONTRIBUTING.md` and followed the table format
- Checked existing PRs and issues for `Tree Ring Memory`
- Searched the README for existing Tree Ring Memory references
- Verified the GitHub repository URL returns HTTP 200
- Ran `git diff --check`

## Classification

- Stack: Rust/SQLite
- Engine: N/A, because this is memory infrastructure rather than an inference backend
- Deployment: CLI/TUI

## Disclosure

I maintain Tree Ring Memory, so I am disclosing the affiliation directly.