### PR TITLE
Add fractal to Programming and Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Development, review, and scaling of source code managed by AI.
 | **Mentat** | CLI abstraction operating over raw file streams and repository graphs for cross-file variable reference propagation. | Python | Hybrid | CLI | [Link](https://github.com/Mentat-AI/mentat) |
 | **Plandex** | Go-based background orchestrator executing iterative refactoring tasks through detached daemon processes and git tracking. | Go | Hybrid | CLI | [Link](https://github.com/plandex-ai/plandex) |
 | **Tabby** | Rust-optimized inference engine providing low-latency FIM (Fill-In-the-Middle) payload processing for code completion. | Rust/Docker | Local Inference | Docker | [Link](https://github.com/TabbyML/tabby) |
+| **fractal** | Hierarchical coding-agent runtime executing recursive loops in per-node Git worktrees with persistent SQLite state and configurable iteration, depth, child, cost, and time limits. | Python | API-based | CLI | [Link](https://github.com/plasma-ai/fractal) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [fractal](https://github.com/plasma-ai/fractal) to **Programming and Coding Agents** using the required six-column table format.

fractal is a Python runtime for hierarchical coding-agent loops. It launches supported coding-agent CLIs in per-node Git worktrees, supports recursive delegation, persists run state in SQLite, and applies configurable iteration, depth, child, cost, and time limits.

Disclosure: I am affiliated with Plasma AI, which maintains fractal.
