### PR TITLE
Add ClawBench to Evaluation Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Parameterized sets of cases for deterministic measurement.
 | **SWE-bench** | Success ratio on repository merges and bug fixes. | Docker/Py | N/A | CLI | [Link](https://github.com/princeton-nlp/SWE-bench) |
 | **AgentBench** | Synthetic agent verification across 8 types of sandbox environments. | Python | N/A | CLI | [Link](https://github.com/THUDM/AgentBench) |
 | **WebArena** | Automated interactivity score across 4 cloned web microservices. | Docker/TS | N/A | CLI | [Link](https://github.com/web-arena-x/webarena) |
+| **ClawBench** | Live-site browser-agent benchmark with 283 V1/V2 tasks and five-layer execution traces. | Python/Docker | N/A | CLI | [Link](https://github.com/TIGER-AI-Lab/ClawBench) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds ClawBench to the existing Evaluation Benchmarks table in the repository's documented six-column format.

ClawBench is an open-source benchmark for browser AI agents. Its V1/V2 suites contain 283 everyday online tasks, and runs use isolated browser containers with five synchronized evidence layers.

- Project: https://claw-bench.com/
- Code: https://github.com/TIGER-AI-Lab/ClawBench
- Paper: https://arxiv.org/abs/2604.08523

## Verification

- Confirmed the repository and all-state PR history had no existing ClawBench entry before submission.
- Followed `CONTRIBUTING.md` and added one project to the existing section.
- `git diff --check` passes and all three ClawBench links return HTTP 200.

## Disclosure

I am a ClawBench maintainer and am submitting this entry for the list maintainers' consideration.
