### PR TITLE
Add Atomic Agent to Programming and Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Development, review, and scaling of source code managed by AI.
 | **Plandex** | Go-based background orchestrator executing iterative refactoring tasks through detached daemon processes and git tracking. | Go | Hybrid | CLI | [Link](https://github.com/plandex-ai/plandex) |
 | **Tabby** | Rust-optimized inference engine providing low-latency FIM (Fill-In-the-Middle) payload processing for code completion. | Rust/Docker | Local Inference | Docker | [Link](https://github.com/TabbyML/tabby) |
 | **fractal** | Hierarchical coding-agent runtime executing recursive loops in per-node Git worktrees with persistent SQLite state and configurable iteration, depth, child, cost, and time limits. | Python | API-based | CLI | [Link](https://github.com/plasma-ai/fractal) |
+| **Atomic Agent** | Coding and agentic runtime running open-weight models entirely on the local machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system. Currently a developer preview: APIs, commands, and config are still moving. | TypeScript | Local Inference | CLI | [Link](https://github.com/AtomicBot-ai/atomic-agent) |
 
 ---
 


### PR DESCRIPTION
## Summary

Hi! I'm the CPO of Atomic Agent. Thanks for putting this list together, the honest technical assessments are what make it useful. Our team would be thrilled if you added us.

Adds [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) to **2. Programming and Coding Agents** using the required six-column table format.

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on the local machine through a llama.cpp fork, so no account or API key is required to install or run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and uses a five-layer local memory system. The TUI is built on React and ink. MIT licensed, cross-platform on macOS, Linux, and Windows.

Classification rationale, per the glossary:

- **Stack:** TypeScript
- **Engine:** Local Inference, since models run locally via a llama.cpp fork rather than through managed external endpoints
- **Deployment:** CLI

Install: `curl -fsSL https://atomicagent.io/install | sh`

One note in the spirit of the list's honest assessments: the project is a developer preview, and APIs, commands, and config are still moving. I included that in the row description rather than leaving it out.

Additional links, in case they are useful: [site](https://atomicagent.io), [docs](https://atomicagent.io/docs), [X](https://x.com/atomicagent_io), [Discord](https://discord.gg/Us7qXtDGw).

## Validation

- verified the canonical GitHub link resolves
- matched the existing six-column row format and appended to the end of the section table
- `git diff --check`
- one project added in one PR, single section, no cross-listing

Disclosure: I am affiliated with AtomicBot-ai, which maintains Atomic Agent. Happy to adjust the wording, classification, or placement to whatever you prefer.
