### PR TITLE
Add Agent Coordinator to Agentic Workflows and Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Integration of agents with APIs, nodes, and conditional process flows.
 | **LLM Workflow Engine** | Pipeline executor processing sequential prompts and branching logic through deterministic finite automata state machines. | Python | Hybrid | Web UI | [Link](https://github.com/llm-workflow-engine/llm-workflow-engine) |
 | **Bee Agent Framework** | Enterprise-grade SDK enforcing hardened guardrails, strict data plane routing, and audit-logging compliance. | TypeScript | Hybrid | Library | [Link](https://github.com/i-am-bee/bee-agent-framework) |
 | **Awesome LLM Apps** | Technical boilerplate and infrastructure definitions for production RAG microservices and scalable vector integrations. | Markdown | N/A | Document | [Link](https://github.com/Shubhamsaboo/awesome-llm-apps) |
+| **Agent Coordinator** | Per-user Codex skill that runs bounded dependency-graph work inline or through optional specialists, stores revisioned local state, rejects concurrent live work with overlapping declared write scopes, reconciles uncertain operations before retry, and reruns authored closeout checks. | Python / Codex Skill | API-based | CLI | [Link](https://github.com/alanhoff/agent-coordinator) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Integration of agents with APIs, nodes, and conditional process flows.
 | **LLM Workflow Engine** | Pipeline executor processing sequential prompts and branching logic through deterministic finite automata state machines. | Python | Hybrid | Web UI | [Link](https://github.com/llm-workflow-engine/llm-workflow-engine) |
 | **Bee Agent Framework** | Enterprise-grade SDK enforcing hardened guardrails, strict data plane routing, and audit-logging compliance. | TypeScript | Hybrid | Library | [Link](https://github.com/i-am-bee/bee-agent-framework) |
 | **Awesome LLM Apps** | Technical boilerplate and infrastructure definitions for production RAG microservices and scalable vector integrations. | Markdown | N/A | Document | [Link](https://github.com/Shubhamsaboo/awesome-llm-apps) |
-| **Agent Coordinator** | Per-user Codex skill that runs bounded dependency-graph work inline or through optional specialists, stores revisioned local state, rejects concurrent live work with overlapping declared write scopes, reconciles uncertain operations before retry, and reruns authored closeout checks. | Python / Codex Skill | API-based | CLI | [Link](https://github.com/alanhoff/agent-coordinator) |
+| **Agent Coordinator** | Per-user Codex skill that runs bounded dependency-graph work inline or through optional specialists, stores revisioned local state, rejects concurrent live work with overlapping declared write scopes, reconciles uncertain operations before retry, and reruns authored closeout checks. | Python/Codex Skill | API-based | CLI | [Link](https://github.com/alanhoff/agent-coordinator) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds Agent Coordinator to section 3, Agentic Workflows and Automation.

Agent Coordinator is a per-user Codex skill for bounded, dependency-aware work. The row describes its optional specialist path, inline execution, revisioned local state, declared write-scope checks, pre-retry reconciliation, and repeatable closeout checks without presenting it as a standalone framework.

## Classification

- Stack: Python / Codex Skill
- Engine: API-based. Codex is the required host, and the project does not ship a local inference engine.
- Deployment: CLI. The per-user skill invokes its bundled state owner through command-line scripts inside Codex tasks.

## Validation

- The canonical repository and direct `skill/SKILL.md` link are public.
- The project is MIT licensed and documents installation, requirements, usage, permissions, local state, and limitations.
- Main is current at `fb3d64688a9e1b7c02a114a14faac1219ec10f51`, with a passing CI run on that commit.
- I found no README, issue, or pull-request duplicate.
- `git diff --check` passes, and this pull request adds one README row in one section.

Disclosure: I maintain Agent Coordinator. I prepared this submission with Codex and reviewed the wording against the public source.
