### PR TITLE
Add YYLO to Programming and Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Development, review, and scaling of source code managed by AI.
 | **Tabby** | Rust-optimized inference engine providing low-latency FIM (Fill-In-the-Middle) payload processing for code completion. | Rust/Docker | Local Inference | Docker | [Link](https://github.com/TabbyML/tabby) |
 | **fractal** | Hierarchical coding-agent runtime executing recursive loops in per-node Git worktrees with persistent SQLite state and configurable iteration, depth, child, cost, and time limits. | Python | API-based | CLI | [Link](https://github.com/plasma-ai/fractal) |
 | **Atomic Agent** | Coding and agentic runtime running open-weight models entirely on the local machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system. Currently a developer preview: APIs, commands, and config are still moving. | TypeScript | Local Inference | CLI | [Link](https://github.com/AtomicBot-ai/atomic-agent) |
+| **YYLO** | Command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. Each task freezes the protected target SHA and runs in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries; the merge queue owns risk-based review. Installs via npm as @yylo/cli and orchestrates Pi and Codex subagents. | Python/TS | API-based | CLI | [Link](https://github.com/yylo-dev/yylo) |
 
 ---
 


### PR DESCRIPTION
## Summary

Hi! I'm on the team that builds YYLO. Thanks for maintaining this list — the six-column format with the glossary classification makes it genuinely useful.

Adds [YYLO](https://github.com/yylo-dev/yylo) to **2. Programming and Coding Agents**, appended to the end of the section table.

YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. Each task freezes the protected target SHA and runs in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries; the merge queue owns risk-based review. It installs via npm as `@yylo/cli` (commands `yylo` / `yy`) and orchestrates Pi and Codex subagents, with `yy ledger` / `yy benchmark` delegating to the separately installed YYLO Ledger and YYLO Benchmark packages.

Classification rationale, per the glossary:

- **Stack:** Python/TS
- **Engine:** API-based — execution delegates to managed coding-agent endpoints (Pi and Codex subagents) rather than local model inference
- **Deployment:** CLI

Install: `npm i -g @yylo/cli`

Activity signals: 57 GitHub stars, MIT licensed, daily pushes since January 2026 (~8 months), npm release published this week.

In the spirit of the list's honest assessments: YYLO is the orchestration layer over coding agents rather than a coding agent itself — it sits alongside Hephaestus, Plandex, and fractal in this section as the runtime that routes and coordinates them. Happy to re-file if you prefer a different section.

## Validation

- verified the canonical GitHub link resolves
- matched the existing six-column row format and appended to the end of the section table
- `git diff --check` clean
- one project added in one PR, single section, no cross-listing

Disclosure: I am on the YYLO team, and this PR was prepared with AI-agent assistance and reviewed before submission. Happy to adjust the wording, classification, or placement to whatever you prefer.
